### PR TITLE
log full `GET` request info

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -34,7 +34,7 @@ func Logger() Handler {
 	return func(ctx *Context, log *log.Logger) {
 		start := time.Now()
 
-		log.Printf("Started %s %s for %s", ctx.Req.Method, ctx.Req.URL.Path, ctx.RemoteAddr())
+		log.Printf("Started %s %s for %s", ctx.Req.Method,ctx.Req.RequestURI, ctx.RemoteAddr())
 
 		rw := ctx.Resp.(ResponseWriter)
 		ctx.Next()


### PR DESCRIPTION
it's more useful to log the entire "RequestURI" than just log "Path"

```
root# go run main.go 
2014/12/21 18:04:27 macaron server running...
[Macaron] listening on 0.0.0.0:5000 (production)
[Macaron] Started GET /info?a=abc for [::1]
[Macaron] Completed /info?a=abc 200 OK in 684.427us
```
