### PR TITLE
Add ETag header to staticHandler

### DIFF
--- a/static_test.go
+++ b/static_test.go
@@ -188,6 +188,21 @@ func Test_Static_Options(t *testing.T) {
 
 		So(resp.Header().Get("Expires"), ShouldEqual, "46")
 	})
+
+	Convey("Serve static files with options ETag", t, func() {
+		var buf bytes.Buffer
+		m := NewWithLogger(&buf)
+		opt := StaticOptions{ETag: true}
+		m.Use(Static(currentRoot, opt))
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "http://localhost:4000/macaron.go", nil)
+		So(err, ShouldBeNil)
+		m.ServeHTTP(resp, req)
+		tag := GenerateETag(string(resp.Body.Len()), "macaron.go", resp.Header().Get("last-modified"))
+
+		So(resp.Header().Get("ETag"), ShouldEqual, tag)
+	})
 }
 
 func Test_Static_Redirect(t *testing.T) {


### PR DESCRIPTION
Adds an ETag header to enable efficient resource update checks: no data is transferred if the resource has not changed.