### PR TITLE
Adds goveralls to ci and badge to display code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,11 @@ go:
   - 1.7
   - tip
 
-script: go test -v -cover -race
+before_install:
+    - go get github.com/mattn/goveralls
+
+script:
+    - $HOME/gopath/bin/goveralls -service=travis-ci
 
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Macaron [![Build Status](https://travis-ci.org/go-macaron/macaron.svg?branch=v1)](https://travis-ci.org/go-macaron/macaron)
+Macaron [![Build Status](https://travis-ci.org/go-macaron/macaron.svg?branch=v1)](https://travis-ci.org/go-macaron/macaron) [![Coverage Status](https://coveralls.io/repos/github/go-macaron/macaron/badge.svg?branch=master)](https://coveralls.io/github/go-macaron/macaron?branch=master)
 =======================
 
 ![Macaron Logo](https://raw.githubusercontent.com/go-macaron/macaron/v1/macaronlogo.png)


### PR DESCRIPTION
Going to https://coveralls.io and synching repos should be done too.

Cheers,
Gorka