### PR TITLE
Method to replace all params

### DIFF
--- a/context.go
+++ b/context.go
@@ -268,6 +268,11 @@ func (ctx *Context) SetParams(name, val string) {
 	ctx.params[name] = val
 }
 
+// ReplaceAllParams replace all current params with given params
+func (ctx *Context) ReplaceAllParams(params Params) {
+	ctx.params = params;
+}
+
 // ParamsEscape returns escapred params result.
 // e.g. ctx.ParamsEscape(":uname")
 func (ctx *Context) ParamsEscape(name string) string {


### PR DESCRIPTION
Adds a `Context.ReplaceAllParams(Params)` method, which sets a context's params.

This method is useful for testing. If one wants to directly test a handler (instead of indirectly testing it via `ServeHTTP(..)`), one needs a way to set the `Context.params` field.