### PR TITLE
Handle URLs with escaped characters

### DIFF
--- a/router.go
+++ b/router.go
@@ -295,7 +295,7 @@ func (r *Router) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			return
 		}
 
-		h, p, ok := t.Match(req.URL.Path)
+		h, p, ok := t.Match(req.URL.EscapedPath())
 		if ok {
 			if splat, ok := p["*0"]; ok {
 				p["*"] = splat // Easy name.

--- a/tree.go
+++ b/tree.go
@@ -15,7 +15,6 @@
 package macaron
 
 import (
-	neturl "net/url"
 	"regexp"
 	"strings"
 
@@ -262,7 +261,7 @@ func (t *Tree) Add(pattern string, handle Handle) *Leaf {
 }
 
 func (t *Tree) matchLeaf(globLevel int, url string, params Params) (Handle, bool) {
-	url, err := neturl.PathUnescape(url)
+	url, err := PathUnescape(url)
 	if err != nil {
 		return nil, false
 	}
@@ -305,7 +304,7 @@ func (t *Tree) matchLeaf(globLevel int, url string, params Params) (Handle, bool
 }
 
 func (t *Tree) matchSubtree(globLevel int, segment, url string, params Params) (Handle, bool) {
-	unescapedSegment, err := neturl.PathUnescape(segment)
+	unescapedSegment, err := PathUnescape(segment)
 	if err != nil {
 		return nil, false
 	}
@@ -344,7 +343,7 @@ func (t *Tree) matchSubtree(globLevel int, segment, url string, params Params) (
 
 	if len(t.leaves) > 0 {
 		leaf := t.leaves[len(t.leaves)-1]
-		unescapedURL, err := neturl.PathUnescape(segment + "/" + url)
+		unescapedURL, err := PathUnescape(segment + "/" + url)
 		if err != nil {
 			return nil, false
 		}

--- a/tree.go
+++ b/tree.go
@@ -15,6 +15,7 @@
 package macaron
 
 import (
+	neturl "net/url"
 	"regexp"
 	"strings"
 
@@ -261,6 +262,10 @@ func (t *Tree) Add(pattern string, handle Handle) *Leaf {
 }
 
 func (t *Tree) matchLeaf(globLevel int, url string, params Params) (Handle, bool) {
+	url, err := neturl.PathUnescape(url)
+	if err != nil {
+		return nil, false
+	}
 	for i := 0; i < len(t.leaves); i++ {
 		switch t.leaves[i].typ {
 		case _PATTERN_STATIC:
@@ -300,16 +305,20 @@ func (t *Tree) matchLeaf(globLevel int, url string, params Params) (Handle, bool
 }
 
 func (t *Tree) matchSubtree(globLevel int, segment, url string, params Params) (Handle, bool) {
+	unescapedSegment, err := neturl.PathUnescape(segment)
+	if err != nil {
+		return nil, false
+	}
 	for i := 0; i < len(t.subtrees); i++ {
 		switch t.subtrees[i].typ {
 		case _PATTERN_STATIC:
-			if t.subtrees[i].pattern == segment {
+			if t.subtrees[i].pattern == unescapedSegment {
 				if handle, ok := t.subtrees[i].matchNextSegment(globLevel, url, params); ok {
 					return handle, true
 				}
 			}
 		case _PATTERN_REGEXP:
-			results := t.subtrees[i].reg.FindStringSubmatch(segment)
+			results := t.subtrees[i].reg.FindStringSubmatch(unescapedSegment)
 			if len(results)-1 != len(t.subtrees[i].wildcards) {
 				break
 			}
@@ -322,12 +331,12 @@ func (t *Tree) matchSubtree(globLevel int, segment, url string, params Params) (
 			}
 		case _PATTERN_HOLDER:
 			if handle, ok := t.subtrees[i].matchNextSegment(globLevel+1, url, params); ok {
-				params[t.subtrees[i].wildcards[0]] = segment
+				params[t.subtrees[i].wildcards[0]] = unescapedSegment
 				return handle, true
 			}
 		case _PATTERN_MATCH_ALL:
 			if handle, ok := t.subtrees[i].matchNextSegment(globLevel+1, url, params); ok {
-				params["*"+com.ToStr(globLevel)] = segment
+				params["*"+com.ToStr(globLevel)] = unescapedSegment
 				return handle, true
 			}
 		}
@@ -335,19 +344,22 @@ func (t *Tree) matchSubtree(globLevel int, segment, url string, params Params) (
 
 	if len(t.leaves) > 0 {
 		leaf := t.leaves[len(t.leaves)-1]
+		unescapedURL, err := neturl.PathUnescape(segment + "/" + url)
+		if err != nil {
+			return nil, false
+		}
 		if leaf.typ == _PATTERN_PATH_EXT {
-			url = segment + "/" + url
-			j := strings.LastIndex(url, ".")
+			j := strings.LastIndex(unescapedURL, ".")
 			if j > -1 {
-				params[":path"] = url[:j]
-				params[":ext"] = url[j+1:]
+				params[":path"] = unescapedURL[:j]
+				params[":ext"] = unescapedURL[j+1:]
 			} else {
-				params[":path"] = url
+				params[":path"] = unescapedURL
 			}
 			return leaf.handle, true
 		} else if leaf.typ == _PATTERN_MATCH_ALL {
-			params["*"] = segment + "/" + url
-			params["*"+com.ToStr(globLevel)] = segment + "/" + url
+			params["*"] = unescapedURL
+			params["*"+com.ToStr(globLevel)] = unescapedURL
 			return leaf.handle, true
 		}
 	}

--- a/tree_test.go
+++ b/tree_test.go
@@ -102,6 +102,9 @@ func Test_Tree_Match(t *testing.T) {
 			_, params, ok = t.Match("/unknwon")
 			So(ok, ShouldBeTrue)
 			So(params[":user"], ShouldEqual, "unknwon")
+			_, params, ok = t.Match("/hello%2Fworld")
+			So(ok, ShouldBeTrue)
+			So(params[":user"], ShouldEqual, "hello/world")
 
 			_, params, ok = t.Match("/user")
 			So(ok, ShouldBeTrue)
@@ -109,6 +112,9 @@ func Test_Tree_Match(t *testing.T) {
 			_, params, ok = t.Match("/user/unknwon")
 			So(ok, ShouldBeTrue)
 			So(params[":name"], ShouldEqual, "unknwon")
+			_, params, ok = t.Match("/hello%20world")
+			So(ok, ShouldBeTrue)
+			So(params[":user"], ShouldEqual, "hello world")
 
 			_, params, ok = t.Match("/user/list/")
 			So(ok, ShouldBeTrue)

--- a/util_go17.go
+++ b/util_go17.go
@@ -1,0 +1,25 @@
+// +build !go1.8
+
+// Copyright 2017 The Macaron Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package macaron
+
+import "net/url"
+
+// PathUnescape unescapes a path. Ideally, this function would use
+// url.PathUnescape(..), but the function was not introduced until go1.8.
+func PathUnescape(s string) (string, error) {
+	return url.QueryUnescape(s)
+}

--- a/util_go18.go
+++ b/util_go18.go
@@ -1,0 +1,24 @@
+// +build go1.8
+
+// Copyright 2017 The Macaron Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License"): you may
+// not use this file except in compliance with the License. You may obtain
+// a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations
+// under the License.
+
+package macaron
+
+import "net/url"
+
+// PathUnescape unescapes a path.
+func PathUnescape(s string) (string, error) {
+	return url.PathUnescape(s)
+}


### PR DESCRIPTION
Allow characters such as `/` inside route parameters when they are properly escaped. See https://github.com/go-gitea/gitea/issues/2869#issuecomment-346289513

cc @svarlamov