### PR TITLE
static: surround ETag with quotes

### DIFF
--- a/static.go
+++ b/static.go
@@ -178,7 +178,7 @@ func staticHandler(ctx *Context, log *log.Logger, opt StaticOptions) bool {
 
 	if opt.ETag {
 		tag := GenerateETag(string(fi.Size()), fi.Name(), fi.ModTime().UTC().Format(http.TimeFormat))
-		ctx.Resp.Header().Set("ETag", tag)
+		ctx.Resp.Header().Set("ETag", `"`+tag+`"`)
 	}
 
 	http.ServeContent(ctx.Resp, ctx.Req.Request, file, fi.ModTime(), f)

--- a/static_test.go
+++ b/static_test.go
@@ -201,7 +201,7 @@ func Test_Static_Options(t *testing.T) {
 		m.ServeHTTP(resp, req)
 		tag := GenerateETag(string(resp.Body.Len()), "macaron.go", resp.Header().Get("last-modified"))
 
-		So(resp.Header().Get("ETag"), ShouldEqual, tag)
+		So(resp.Header().Get("ETag"), ShouldEqual, `"`+tag+`"`)
 	})
 }
 


### PR DESCRIPTION
Surrounds ETag with quote so it can be properly validated, as described by #193. 