### PR TITLE
static: clean the path URL before redirecting

### DIFF
--- a/static.go
+++ b/static.go
@@ -123,7 +123,7 @@ func staticHandler(ctx *Context, log *log.Logger, opt StaticOptions) bool {
 		return false
 	}
 
-	file := path.Clean(ctx.Req.URL.Path)
+	file := ctx.Req.URL.Path
 	// if we have a prefix, filter requests by stripping the prefix
 	if opt.Prefix != "" {
 		if !strings.HasPrefix(file, opt.Prefix) {

--- a/static.go
+++ b/static.go
@@ -123,7 +123,7 @@ func staticHandler(ctx *Context, log *log.Logger, opt StaticOptions) bool {
 		return false
 	}
 
-	file := ctx.Req.URL.Path
+	file := path.Clean(ctx.Req.URL.Path)
 	// if we have a prefix, filter requests by stripping the prefix
 	if opt.Prefix != "" {
 		if !strings.HasPrefix(file, opt.Prefix) {
@@ -149,8 +149,9 @@ func staticHandler(ctx *Context, log *log.Logger, opt StaticOptions) bool {
 	// Try to serve index file
 	if fi.IsDir() {
 		// Redirect if missing trailing slash.
-		if !strings.HasSuffix(ctx.Req.URL.Path, "/") {
-			http.Redirect(ctx.Resp, ctx.Req.Request, ctx.Req.URL.Path+"/", http.StatusFound)
+		redirPath := path.Clean(ctx.Req.URL.Path)
+		if !strings.HasSuffix(redirPath, "/") {
+			http.Redirect(ctx.Resp, ctx.Req.Request, redirPath+"/", http.StatusFound)
 			return true
 		}
 

--- a/static_test.go
+++ b/static_test.go
@@ -229,6 +229,7 @@ func Test_Static_Redirect(t *testing.T) {
 		m.ServeHTTP(resp, req)
 
 		So(resp.Code, ShouldEqual, http.StatusNotFound)
+		So(resp.Header().Get("Location"), ShouldEqual, "/example.com%2f..")
 	})
 }
 

--- a/static_test.go
+++ b/static_test.go
@@ -229,7 +229,7 @@ func Test_Static_Redirect(t *testing.T) {
 		m.ServeHTTP(resp, req)
 
 		So(resp.Code, ShouldEqual, http.StatusNotFound)
-		So(resp.Header().Get("Location"), ShouldEqual, "/example.com%2f..")
+		So(resp.Header().Get("Location"), ShouldEqual, "/example.com%2f../")
 	})
 }
 

--- a/static_test.go
+++ b/static_test.go
@@ -218,6 +218,18 @@ func Test_Static_Redirect(t *testing.T) {
 		So(resp.Code, ShouldEqual, http.StatusFound)
 		So(resp.Header().Get("Location"), ShouldEqual, "/public/")
 	})
+
+	Convey("Serve static files with improper request", t, func() {
+		m := New()
+		m.Use(Static(currentRoot))
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", `http://localhost:4000//example.com%2f..`, nil)
+		So(err, ShouldBeNil)
+		m.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusNotFound)
+	})
 }
 
 func Test_Statics(t *testing.T) {

--- a/static_test.go
+++ b/static_test.go
@@ -229,7 +229,6 @@ func Test_Static_Redirect(t *testing.T) {
 		m.ServeHTTP(resp, req)
 
 		So(resp.Code, ShouldEqual, http.StatusNotFound)
-		So(resp.Header().Get("Location"), ShouldEqual, "/example.com%2f../")
 	})
 }
 


### PR DESCRIPTION
This prevents a malicious redirect with a crafted URL. Resolves #198.

It prevents links such as:
`http://localhost:4000/%2fhumaidq.ae%2f..`
`http://localhost:4000//humaidq.ae%2f..`
from giving a 302 Found redirecting to `humaidq.ae`