### PR TITLE
static: handle If-None-Match for ETag.

### DIFF
--- a/static.go
+++ b/static.go
@@ -178,8 +178,12 @@ func staticHandler(ctx *Context, log *log.Logger, opt StaticOptions) bool {
 	}
 
 	if opt.ETag {
-		tag := GenerateETag(string(fi.Size()), fi.Name(), fi.ModTime().UTC().Format(http.TimeFormat))
-		ctx.Resp.Header().Set("ETag", `"`+tag+`"`)
+		tag := `"` + GenerateETag(string(fi.Size()), fi.Name(), fi.ModTime().UTC().Format(http.TimeFormat)) + `"`
+		ctx.Resp.Header().Set("ETag", tag)
+		if ctx.Req.Header.Get("If-None-Match") == tag {
+			ctx.Resp.WriteHeader(http.StatusNotModified)
+			return true
+		}
 	}
 
 	http.ServeContent(ctx.Resp, ctx.Req.Request, file, fi.ModTime(), f)


### PR DESCRIPTION
We handle the `If-None-Match` header, and if it matches the current ETag then don't resend the resource and return a 304 Not Modified. The header value is also surrounded with `"`.

This resolves #152.

Thank you.