### PR TITLE
static: fix infinite redirection when prefix is set

### DIFF
--- a/static.go
+++ b/static.go
@@ -150,6 +150,9 @@ func staticHandler(ctx *Context, log *log.Logger, opt StaticOptions) bool {
 	if fi.IsDir() {
 		// Redirect if missing trailing slash.
 		redirPath := path.Clean(ctx.Req.URL.Path)
+		if strings.HasSuffix(ctx.Req.URL.Path, "/") {
+			redirPath = redirPath + "/"
+		}
 		if !strings.HasSuffix(redirPath, "/") {
 			http.Redirect(ctx.Resp, ctx.Req.Request, redirPath+"/", http.StatusFound)
 			return true

--- a/static.go
+++ b/static.go
@@ -148,11 +148,13 @@ func staticHandler(ctx *Context, log *log.Logger, opt StaticOptions) bool {
 
 	// Try to serve index file
 	if fi.IsDir() {
-		// Redirect if missing trailing slash.
 		redirPath := path.Clean(ctx.Req.URL.Path)
+		// path.Clean removes the trailing slash, so we need to add it back when
+		// the original path has it.
 		if strings.HasSuffix(ctx.Req.URL.Path, "/") {
 			redirPath = redirPath + "/"
 		}
+		// Redirect if missing trailing slash.
 		if !strings.HasSuffix(redirPath, "/") {
 			http.Redirect(ctx.Resp, ctx.Req.Request, redirPath+"/", http.StatusFound)
 			return true

--- a/static_test.go
+++ b/static_test.go
@@ -224,6 +224,19 @@ func Test_Static_Options(t *testing.T) {
 }
 
 func Test_Static_Redirect(t *testing.T) {
+	Convey("Serve static files with prefix without redirect", t, func() {
+		m := New()
+		opt := StaticOptions{Prefix: "/public"}
+		m.Use(Static(currentRoot, opt))
+
+		resp := httptest.NewRecorder()
+		req, err := http.NewRequest("GET", "http://localhost:4000/public/", nil)
+		So(err, ShouldBeNil)
+		m.ServeHTTP(resp, req)
+
+		So(resp.Code, ShouldEqual, http.StatusNotFound)
+	})
+
 	Convey("Serve static files with redirect", t, func() {
 		m := New()
 		m.Use(Static(currentRoot, StaticOptions{Prefix: "/public"}))


### PR DESCRIPTION
This resolves the infinite redirection bug when viewing an index in a static files directory, as `path.Clean` removes the trailing slash. Fixes #201.  
This is mostly a hack on top of `path.Clean`, as we are re-adding the trailing slash.