### PR TITLE
Convert int to string using fmt.Sprintf

### DIFF
--- a/static.go
+++ b/static.go
@@ -17,6 +17,7 @@ package macaron
 
 import (
 	"encoding/base64"
+	"fmt"
 	"log"
 	"net/http"
 	"path"
@@ -183,7 +184,7 @@ func staticHandler(ctx *Context, log *log.Logger, opt StaticOptions) bool {
 	}
 
 	if opt.ETag {
-		tag := `"` + GenerateETag(string(fi.Size()), fi.Name(), fi.ModTime().UTC().Format(http.TimeFormat)) + `"`
+		tag := `"` + GenerateETag(fmt.Sprintf("%d", fi.Size()), fi.Name(), fi.ModTime().UTC().Format(http.TimeFormat)) + `"`
 		ctx.Resp.Header().Set("ETag", tag)
 		if ctx.Req.Header.Get("If-None-Match") == tag {
 			ctx.Resp.WriteHeader(http.StatusNotModified)

--- a/static_test.go
+++ b/static_test.go
@@ -17,6 +17,7 @@ package macaron
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -197,7 +198,7 @@ func Test_Static_Options(t *testing.T) {
 		req, err := http.NewRequest("GET", "http://localhost:4000/macaron.go", nil)
 		So(err, ShouldBeNil)
 		m.ServeHTTP(resp, req)
-		tag := GenerateETag(string(resp.Body.Len()), "macaron.go", resp.Header().Get("last-modified"))
+		tag := GenerateETag(fmt.Sprintf("%d", resp.Body.Len()), "macaron.go", resp.Header().Get("last-modified"))
 
 		So(resp.Header().Get("ETag"), ShouldEqual, `"`+tag+`"`)
 	})
@@ -211,7 +212,7 @@ func Test_Static_Options(t *testing.T) {
 		req, err := http.NewRequest("GET", "http://localhost:4000/macaron.go", nil)
 		So(err, ShouldBeNil)
 		m.ServeHTTP(resp, req)
-		tag := GenerateETag(string(resp.Body.Len()), "macaron.go", resp.Header().Get("last-modified"))
+		tag := GenerateETag(fmt.Sprintf("%d", resp.Body.Len()), "macaron.go", resp.Header().Get("last-modified"))
 
 		// Second request with ETag in If-None-Match
 		resp = httptest.NewRecorder()


### PR DESCRIPTION
See https://github.com/golang/go/issues/32479

Fix #204.

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>