### PR TITLE
add ability to set SameSite attribute for cookie

### DIFF
--- a/context.go
+++ b/context.go
@@ -381,6 +381,22 @@ func (ctx *Context) SetCookie(name string, value string, others ...interface{}) 
 		}
 	}
 
+	if len(others) > 6 {
+		switch v := others[6].(type) {
+		case bool:
+			if v {
+				cookie.SameSite = http.SameSiteStrictMode
+			} else {
+				cookie.SameSite = http.SameSiteLaxMode
+			}
+			break
+		default:
+			if others[6] != nil {
+				cookie.SameSite = http.SameSiteLaxMode
+			}
+		}
+	}
+
 	ctx.Resp.Header().Add("Set-Cookie", cookie.String())
 }
 

--- a/context.go
+++ b/context.go
@@ -389,7 +389,6 @@ func (ctx *Context) SetCookie(name string, value string, others ...interface{}) 
 			} else {
 				cookie.SameSite = http.SameSiteLaxMode
 			}
-			break
 		default:
 			if others[6] != nil {
 				cookie.SameSite = http.SameSiteLaxMode


### PR DESCRIPTION
Hi,

this PR adds the ability to set the `SameSite` attribute of a cookie. 
Same as in go-macaron/session#38, the default value is `false` (`Lax`) and `true` sets it to `Strict`.
