### PR TITLE
refactor: replace interface{} with any (Go 1.18+)

### DIFF
--- a/context.go
+++ b/context.go
@@ -38,7 +38,7 @@ import (
 // Locale reprents a localization interface.
 type Locale interface {
 	Language() string
-	Tr(string, ...interface{}) string
+	Tr(string, ...any) string
 }
 
 // RequestBody represents a request body.
@@ -76,7 +76,7 @@ func (r *Request) Body() *RequestBody {
 type ContextInvoker func(ctx *Context)
 
 // Invoke implements inject.FastInvoker which simplifies calls of `func(ctx *Context)` function.
-func (invoke ContextInvoker) Invoke(params []interface{}) ([]reflect.Value, error) {
+func (invoke ContextInvoker) Invoke(params []any) ([]reflect.Value, error) {
 	invoke(params[0].(*Context))
 	return nil, nil
 }
@@ -95,7 +95,7 @@ type Context struct {
 	params Params
 	Render
 	Locale
-	Data map[string]interface{}
+	Data map[string]any
 }
 
 func (ctx *Context) handler() Handler {
@@ -155,7 +155,7 @@ func (ctx *Context) RemoteAddr() string {
 	return addr
 }
 
-func (ctx *Context) renderHTML(status int, setName, tplName string, data ...interface{}) {
+func (ctx *Context) renderHTML(status int, setName, tplName string, data ...any) {
 	if len(data) <= 0 {
 		ctx.Render.HTMLSet(status, setName, tplName, ctx.Data)
 	} else if len(data) == 1 {
@@ -166,12 +166,12 @@ func (ctx *Context) renderHTML(status int, setName, tplName string, data ...inte
 }
 
 // HTML renders the HTML with default template set.
-func (ctx *Context) HTML(status int, name string, data ...interface{}) {
+func (ctx *Context) HTML(status int, name string, data ...any) {
 	ctx.renderHTML(status, DEFAULT_TPL_SET_NAME, name, data...)
 }
 
 // HTMLSet renders the HTML with given template set name.
-func (ctx *Context) HTMLSet(status int, setName, tplName string, data ...interface{}) {
+func (ctx *Context) HTMLSet(status int, setName, tplName string, data ...any) {
 	ctx.renderHTML(status, setName, tplName, data...)
 }
 
@@ -332,7 +332,7 @@ func (ctx *Context) SaveToFile(name, savePath string) error {
 
 // SetCookie sets given cookie value to response header.
 // FIXME: IE support? http://golanghome.com/post/620#reply2
-func (ctx *Context) SetCookie(name string, value string, others ...interface{}) {
+func (ctx *Context) SetCookie(name string, value string, others ...any) {
 	cookie := http.Cookie{}
 	cookie.Name = name
 	cookie.Value = url.QueryEscape(value)
@@ -442,7 +442,7 @@ func (m *Macaron) SetDefaultCookieSecret(secret string) {
 }
 
 // SetSecureCookie sets given cookie value to response header with default secret string.
-func (ctx *Context) SetSecureCookie(name, value string, others ...interface{}) {
+func (ctx *Context) SetSecureCookie(name, value string, others ...any) {
 	ctx.SetSuperSecureCookie(defaultCookieSecret, name, value, others...)
 }
 
@@ -452,7 +452,7 @@ func (ctx *Context) GetSecureCookie(key string) (string, bool) {
 }
 
 // SetSuperSecureCookie sets given cookie value to response header with secret string.
-func (ctx *Context) SetSuperSecureCookie(secret, name, value string, others ...interface{}) {
+func (ctx *Context) SetSuperSecureCookie(secret, name, value string, others ...any) {
 	key := pbkdf2.Key([]byte(secret), []byte(secret), 1000, 16, sha256.New)
 	text, err := com.AESGCMEncrypt(key, []byte(value))
 	if err != nil {
@@ -488,7 +488,7 @@ func (ctx *Context) setRawContentHeader() {
 }
 
 // ServeContent serves given content to response.
-func (ctx *Context) ServeContent(name string, r io.ReadSeeker, params ...interface{}) {
+func (ctx *Context) ServeContent(name string, r io.ReadSeeker, params ...any) {
 	modtime := time.Now()
 	for _, p := range params {
 		switch v := p.(type) {

--- a/context_test.go
+++ b/context_test.go
@@ -394,7 +394,7 @@ func Test_Context_Redirect(t *testing.T) {
 		ctx := &Context{
 			Req:  Request{&req},
 			Resp: NewResponseWriter(req.Method, resp),
-			Data: make(map[string]interface{}),
+			Data: make(map[string]any),
 		}
 		ctx.Redirect("two")
 
@@ -413,7 +413,7 @@ func Test_Context_Redirect(t *testing.T) {
 		ctx := &Context{
 			Req:  Request{&req},
 			Resp: NewResponseWriter(req.Method, resp),
-			Data: make(map[string]interface{}),
+			Data: make(map[string]any),
 		}
 		ctx.Redirect("two", 307)
 

--- a/logger.go
+++ b/logger.go
@@ -36,7 +36,7 @@ func init() {
 // LoggerInvoker is an inject.FastInvoker wrapper of func(ctx *Context, log *log.Logger).
 type LoggerInvoker func(ctx *Context, log *log.Logger)
 
-func (invoke LoggerInvoker) Invoke(params []interface{}) ([]reflect.Value, error) {
+func (invoke LoggerInvoker) Invoke(params []any) ([]reflect.Value, error) {
 	invoke(params[0].(*Context), params[1].(*log.Logger))
 	return nil, nil
 }

--- a/macaron.go
+++ b/macaron.go
@@ -39,12 +39,12 @@ func Version() string {
 // Handler can be any callable function.
 // Macaron attempts to inject services into the handler's argument list,
 // and panics if an argument could not be fullfilled via dependency injection.
-type Handler interface{}
+type Handler any
 
 // handlerFuncInvoker is an inject.FastInvoker wrapper of func(http.ResponseWriter, *http.Request).
 type handlerFuncInvoker func(http.ResponseWriter, *http.Request)
 
-func (invoke handlerFuncInvoker) Invoke(params []interface{}) ([]reflect.Value, error) {
+func (invoke handlerFuncInvoker) Invoke(params []any) ([]reflect.Value, error) {
 	invoke(params[0].(http.ResponseWriter), params[1].(*http.Request))
 	return nil, nil
 }
@@ -52,7 +52,7 @@ func (invoke handlerFuncInvoker) Invoke(params []interface{}) ([]reflect.Value, 
 // internalServerErrorInvoker is an inject.FastInvoker wrapper of func(rw http.ResponseWriter, err error).
 type internalServerErrorInvoker func(rw http.ResponseWriter, err error)
 
-func (invoke internalServerErrorInvoker) Invoke(params []interface{}) ([]reflect.Value, error) {
+func (invoke internalServerErrorInvoker) Invoke(params []any) ([]reflect.Value, error) {
 	invoke(params[0].(http.ResponseWriter), params[1].(error))
 	return nil, nil
 }
@@ -194,7 +194,7 @@ func (m *Macaron) createContext(rw http.ResponseWriter, req *http.Request) *Cont
 		Req:      Request{req},
 		Resp:     NewResponseWriter(req.Method, rw),
 		Render:   &DummyRender{rw},
-		Data:     make(map[string]interface{}),
+		Data:     make(map[string]any),
 	}
 	c.SetParent(m)
 	c.Map(c)
@@ -231,7 +231,7 @@ func GetDefaultListenInfo() (string, int) {
 }
 
 // Run the http server. Listening on os.GetEnv("PORT") or 4000 by default.
-func (m *Macaron) Run(args ...interface{}) {
+func (m *Macaron) Run(args ...any) {
 	host, port := GetDefaultListenInfo()
 	if len(args) == 1 {
 		switch arg := args[0].(type) {
@@ -317,7 +317,7 @@ func init() {
 }
 
 // SetConfig sets data sources for configuration.
-func SetConfig(source interface{}, others ...interface{}) (_ *ini.File, err error) {
+func SetConfig(source any, others ...any) (_ *ini.File, err error) {
 	cfg, err = ini.Load(source, others...)
 	return Config(), err
 }

--- a/render.go
+++ b/render.go
@@ -47,7 +47,7 @@ const (
 var (
 	// Provides a temporary buffer to execute templates into and catch errors.
 	bufpool = sync.Pool{
-		New: func() interface{} { return new(bytes.Buffer) },
+		New: func() any { return new(bytes.Buffer) },
 	}
 
 	// Included helper functions for use when rendering html
@@ -122,17 +122,17 @@ type (
 		http.ResponseWriter
 		SetResponseWriter(http.ResponseWriter)
 
-		JSON(int, interface{})
-		JSONString(interface{}) (string, error)
+		JSON(int, any)
+		JSONString(any) (string, error)
 		RawData(int, []byte)   // Serve content as binary
 		PlainText(int, []byte) // Serve content as plain text
-		HTML(int, string, interface{}, ...HTMLOptions)
-		HTMLSet(int, string, string, interface{}, ...HTMLOptions)
-		HTMLSetString(string, string, interface{}, ...HTMLOptions) (string, error)
-		HTMLString(string, interface{}, ...HTMLOptions) (string, error)
-		HTMLSetBytes(string, string, interface{}, ...HTMLOptions) ([]byte, error)
-		HTMLBytes(string, interface{}, ...HTMLOptions) ([]byte, error)
-		XML(int, interface{})
+		HTML(int, string, any, ...HTMLOptions)
+		HTMLSet(int, string, string, any, ...HTMLOptions)
+		HTMLSetString(string, string, any, ...HTMLOptions) (string, error)
+		HTMLString(string, any, ...HTMLOptions) (string, error)
+		HTMLSetBytes(string, string, any, ...HTMLOptions) ([]byte, error)
+		HTMLBytes(string, any, ...HTMLOptions) ([]byte, error)
+		XML(int, any)
 		Error(int, ...string)
 		Status(int)
 		SetTemplatePath(string, string)
@@ -437,7 +437,7 @@ func (r *TplRender) SetResponseWriter(rw http.ResponseWriter) {
 	r.ResponseWriter = rw
 }
 
-func (r *TplRender) JSON(status int, v interface{}) {
+func (r *TplRender) JSON(status int, v any) {
 	var (
 		result []byte
 		err    error
@@ -461,7 +461,7 @@ func (r *TplRender) JSON(status int, v interface{}) {
 	_, _ = r.Write(result)
 }
 
-func (r *TplRender) JSONString(v interface{}) (string, error) {
+func (r *TplRender) JSONString(v any) (string, error) {
 	var result []byte
 	var err error
 	if r.Opt.IndentJSON {
@@ -475,7 +475,7 @@ func (r *TplRender) JSONString(v interface{}) (string, error) {
 	return string(result), nil
 }
 
-func (r *TplRender) XML(status int, v interface{}) {
+func (r *TplRender) XML(status int, v any) {
 	var result []byte
 	var err error
 	if r.Opt.IndentXML {
@@ -513,12 +513,12 @@ func (r *TplRender) PlainText(status int, v []byte) {
 	r.data(status, _CONTENT_PLAIN, v)
 }
 
-func (r *TplRender) execute(t *template.Template, name string, data interface{}) (*bytes.Buffer, error) {
+func (r *TplRender) execute(t *template.Template, name string, data any) (*bytes.Buffer, error) {
 	buf := bufpool.Get().(*bytes.Buffer)
 	return buf, t.ExecuteTemplate(buf, name, data)
 }
 
-func (r *TplRender) addYield(t *template.Template, tplName string, data interface{}) {
+func (r *TplRender) addYield(t *template.Template, tplName string, data any) {
 	funcs := template.FuncMap{
 		"yield": func() (template.HTML, error) {
 			buf, err := r.execute(t, tplName, data)
@@ -532,7 +532,7 @@ func (r *TplRender) addYield(t *template.Template, tplName string, data interfac
 	t.Funcs(funcs)
 }
 
-func (r *TplRender) renderBytes(setName, tplName string, data interface{}, htmlOpt ...HTMLOptions) (*bytes.Buffer, error) {
+func (r *TplRender) renderBytes(setName, tplName string, data any, htmlOpt ...HTMLOptions) (*bytes.Buffer, error) {
 	t := r.Get(setName)
 	if Env == DEV {
 		opt := *r.Opt
@@ -558,7 +558,7 @@ func (r *TplRender) renderBytes(setName, tplName string, data interface{}, htmlO
 	return out, nil
 }
 
-func (r *TplRender) renderHTML(status int, setName, tplName string, data interface{}, htmlOpt ...HTMLOptions) {
+func (r *TplRender) renderHTML(status int, setName, tplName string, data any, htmlOpt ...HTMLOptions) {
 	r.startTime = time.Now()
 
 	out, err := r.renderBytes(setName, tplName, data, htmlOpt...)
@@ -576,15 +576,15 @@ func (r *TplRender) renderHTML(status int, setName, tplName string, data interfa
 	bufpool.Put(out)
 }
 
-func (r *TplRender) HTML(status int, name string, data interface{}, htmlOpt ...HTMLOptions) {
+func (r *TplRender) HTML(status int, name string, data any, htmlOpt ...HTMLOptions) {
 	r.renderHTML(status, DEFAULT_TPL_SET_NAME, name, data, htmlOpt...)
 }
 
-func (r *TplRender) HTMLSet(status int, setName, tplName string, data interface{}, htmlOpt ...HTMLOptions) {
+func (r *TplRender) HTMLSet(status int, setName, tplName string, data any, htmlOpt ...HTMLOptions) {
 	r.renderHTML(status, setName, tplName, data, htmlOpt...)
 }
 
-func (r *TplRender) HTMLSetBytes(setName, tplName string, data interface{}, htmlOpt ...HTMLOptions) ([]byte, error) {
+func (r *TplRender) HTMLSetBytes(setName, tplName string, data any, htmlOpt ...HTMLOptions) ([]byte, error) {
 	out, err := r.renderBytes(setName, tplName, data, htmlOpt...)
 	if err != nil {
 		return []byte(""), err
@@ -592,16 +592,16 @@ func (r *TplRender) HTMLSetBytes(setName, tplName string, data interface{}, html
 	return out.Bytes(), nil
 }
 
-func (r *TplRender) HTMLBytes(name string, data interface{}, htmlOpt ...HTMLOptions) ([]byte, error) {
+func (r *TplRender) HTMLBytes(name string, data any, htmlOpt ...HTMLOptions) ([]byte, error) {
 	return r.HTMLSetBytes(DEFAULT_TPL_SET_NAME, name, data, htmlOpt...)
 }
 
-func (r *TplRender) HTMLSetString(setName, tplName string, data interface{}, htmlOpt ...HTMLOptions) (string, error) {
+func (r *TplRender) HTMLSetString(setName, tplName string, data any, htmlOpt ...HTMLOptions) (string, error) {
 	p, err := r.HTMLSetBytes(setName, tplName, data, htmlOpt...)
 	return string(p), err
 }
 
-func (r *TplRender) HTMLString(name string, data interface{}, htmlOpt ...HTMLOptions) (string, error) {
+func (r *TplRender) HTMLString(name string, data any, htmlOpt ...HTMLOptions) (string, error) {
 	p, err := r.HTMLBytes(name, data, htmlOpt...)
 	return string(p), err
 }
@@ -656,11 +656,11 @@ func (r *DummyRender) SetResponseWriter(http.ResponseWriter) {
 	renderNotRegistered()
 }
 
-func (r *DummyRender) JSON(int, interface{}) {
+func (r *DummyRender) JSON(int, any) {
 	renderNotRegistered()
 }
 
-func (r *DummyRender) JSONString(interface{}) (string, error) {
+func (r *DummyRender) JSONString(any) (string, error) {
 	renderNotRegistered()
 	return "", nil
 }
@@ -673,35 +673,35 @@ func (r *DummyRender) PlainText(int, []byte) {
 	renderNotRegistered()
 }
 
-func (r *DummyRender) HTML(int, string, interface{}, ...HTMLOptions) {
+func (r *DummyRender) HTML(int, string, any, ...HTMLOptions) {
 	renderNotRegistered()
 }
 
-func (r *DummyRender) HTMLSet(int, string, string, interface{}, ...HTMLOptions) {
+func (r *DummyRender) HTMLSet(int, string, string, any, ...HTMLOptions) {
 	renderNotRegistered()
 }
 
-func (r *DummyRender) HTMLSetString(string, string, interface{}, ...HTMLOptions) (string, error) {
-	renderNotRegistered()
-	return "", nil
-}
-
-func (r *DummyRender) HTMLString(string, interface{}, ...HTMLOptions) (string, error) {
+func (r *DummyRender) HTMLSetString(string, string, any, ...HTMLOptions) (string, error) {
 	renderNotRegistered()
 	return "", nil
 }
 
-func (r *DummyRender) HTMLSetBytes(string, string, interface{}, ...HTMLOptions) ([]byte, error) {
+func (r *DummyRender) HTMLString(string, any, ...HTMLOptions) (string, error) {
+	renderNotRegistered()
+	return "", nil
+}
+
+func (r *DummyRender) HTMLSetBytes(string, string, any, ...HTMLOptions) ([]byte, error) {
 	renderNotRegistered()
 	return nil, nil
 }
 
-func (r *DummyRender) HTMLBytes(string, interface{}, ...HTMLOptions) ([]byte, error) {
+func (r *DummyRender) HTMLBytes(string, any, ...HTMLOptions) ([]byte, error) {
 	renderNotRegistered()
 	return nil, nil
 }
 
-func (r *DummyRender) XML(int, interface{}) {
+func (r *DummyRender) XML(int, any) {
 	renderNotRegistered()
 }
 

--- a/return_handler_test.go
+++ b/return_handler_test.go
@@ -26,7 +26,7 @@ import (
 
 type r1Invoker func() (int, string)
 
-func (l r1Invoker) Invoke(p []interface{}) ([]reflect.Value, error) {
+func (l r1Invoker) Invoke(p []any) ([]reflect.Value, error) {
 	ret, str := l()
 	return []reflect.Value{reflect.ValueOf(ret), reflect.ValueOf(str)}, nil
 }

--- a/router_test.go
+++ b/router_test.go
@@ -35,7 +35,7 @@ func Test_Router_FastInvoker_Handle(t *testing.T) {
 type handlerFunc0Invoker func() string
 
 // Invoke handlerFunc0Invoker
-func (l handlerFunc0Invoker) Invoke(p []interface{}) ([]reflect.Value, error) {
+func (l handlerFunc0Invoker) Invoke(p []any) ([]reflect.Value, error) {
 	ret := l()
 	return []reflect.Value{reflect.ValueOf(ret)}, nil
 }


### PR DESCRIPTION
Replace all occurrences of `interface{}` with `any` (available since Go 1.18) across 7 files.